### PR TITLE
Replace `--strict` command-line option with `--strict-markers`

### DIFF
--- a/tests/test_pytest_pycodestyle.py
+++ b/tests/test_pytest_pycodestyle.py
@@ -83,7 +83,7 @@ def test_strict(testdir):
             pass
     """)
     p = p.write(p.read() + "\n")
-    result = testdir.runpytest('--strict', '--pycodestyle')
+    result = testdir.runpytest('--strict-markers', '--pycodestyle')
     result.assert_outcomes(passed=2)
 
 


### PR DESCRIPTION
https://docs.pytest.org/en/latest/deprecations.html#the-strict-command-line-option
```
$ pytest -s tests
../../../../../../../../../Users/henry/.pyenv/versions/3.9.10/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/_pytest/config/__init__.py:1195
  /Users/henry/.pyenv/versions/3.9.10/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/_pytest/config/__init__.py:1195: PytestRemovedIn8Warning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(
```