### PR TITLE
Update MANIFEST.in to add tests and Makefile to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include LICENSE
+include Makefile
 include README.md
 include VERSION
+recursive-include tests *.py


### PR DESCRIPTION
https://github.com/henry0312/pytest-pydocstyle/issues/86

```
❯ check-manifest
lists of files in version control and sdist do not match!
missing from sdist:
  Makefile
  tests/test_pytest_pycodestyle.py
suggested MANIFEST.in rules:
  include Makefile
  recursive-include tests *.py
```