### PR TITLE
Update `pytest_collect_file` hook to remove deprecated `path` argument

### DIFF
--- a/src/pytest_pycodestyle.py
+++ b/src/pytest_pycodestyle.py
@@ -19,11 +19,11 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'pycodestyle: mark tests to be checked by pycodestyle.')
 
 
-def pytest_collect_file(file_path: pathlib.Path, path, parent):
+def pytest_collect_file(file_path: pathlib.Path, parent):
     """Create a Collector for the given path, or None if not relevant.
 
     See:
-      - https://docs.pytest.org/en/7.0.x/reference/reference.html#pytest.hookspec.pytest_collect_file
+      - https://docs.pytest.org/en/8.3.x/reference/reference.html#pytest.hookspec.pytest_collect_file
     """
     config = parent.config
     if config.getoption('pycodestyle') and file_path.suffix == '.py':


### PR DESCRIPTION
Replaced the deprecated `path` argument with `file_path: pathlib.Path` in the `pytest_collect_file` hook to address PytestRemovedIn9Warning.

```
tests/test_pytest_pycodestyle.py: 10 warnings
  /home/runner/work/pytest-pycodestyle/pytest-pycodestyle/src/pytest_pycodestyle.py:22: PytestRemovedIn9Warning: The (path: py.path.local) argument is deprecated, please use (file_path: pathlib.Path)
  see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
    def pytest_collect_file(file_path: pathlib.Path, path, parent):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```